### PR TITLE
Adds CSS rules to `view_text.php` to create uniform vertical spacing …

### DIFF
--- a/view_text.php
+++ b/view_text.php
@@ -53,6 +53,13 @@ if (!$text_id || $text_id <= 0) {
         .theme-switcher select { margin: 0 0.5rem; padding: 0.25rem 0.5rem; }
         .theme-switcher button { padding: 0.25rem 0.75rem; font-size: 0.8rem; }
         .content-body { line-height: 1.6; white-space: pre-wrap; }
+        .content-body > * {
+            margin-top: 0;
+            margin-bottom: 1em;
+        }
+        .content-body > *:last-child {
+            margin-bottom: 0;
+        }
         .back-link { display: inline-block; margin-bottom: 2rem; }
         .error { color: #721c24; background-color: #f8d7da; padding: 1rem; border-radius: 4px; }
     </style>


### PR DESCRIPTION
…for content rendered from Markdown.

This change overrides default browser styles for elements like `<p>`, `<h1>`, etc., fixing the issue of excessive and inconsistent margins between generated content blocks.

- Sets a consistent `margin-bottom` for all direct children of the `.content-body` container.
- Removes the `margin-bottom` from the last child to prevent extra space at the end of the article.