### PR TITLE
The icons in the EasyMDE toolbar on the edit_article.php page were in…

### DIFF
--- a/assets/css/light-theme.css
+++ b/assets/css/light-theme.css
@@ -81,3 +81,9 @@ hr {
     border-top: 1px solid #eee;
     margin: 2rem 0;
 }
+
+/* --- Fix for EasyMDE Toolbar Icons --- */
+/* Override the default button color for the markdown editor to ensure icons are visible. */
+.editor-toolbar button {
+    color: #333 !important; /* Use !important to ensure override */
+}


### PR DESCRIPTION
…visible due to a CSS conflict. The global style for buttons in light-theme.css set the text color to white, which made the white icons disappear on the white toolbar background. This change adds a more specific CSS rule to override the button color for the EasyMDE toolbar, ensuring the icons are visible.