### PR TITLE
The icons and buttons in the EasyMDE toolbar on the edit_article.php …

### DIFF
--- a/assets/css/light-theme.css
+++ b/assets/css/light-theme.css
@@ -81,3 +81,17 @@ hr {
     border-top: 1px solid #eee;
     margin: 2rem 0;
 }
+
+/* --- Fix for EasyMDE Toolbar Icons --- */
+/* Override default styles for the markdown editor to ensure toolbar is visible in the light theme. */
+.editor-toolbar button {
+    color: #333 !important; /* Ensure icons are dark */
+    background-color: #f0f0f0; /* Make button background visible */
+    border: 1px solid #ccc;
+}
+
+.editor-toolbar button:hover,
+.editor-toolbar button.active {
+    background-color: #e0e0e0;
+    border-color: #bbb;
+}


### PR DESCRIPTION
…page were invisible due to a CSS conflict. The global button style set the icon color to white, and the editor's default transparent background made the buttons themselves invisible against the white toolbar. This change overrides the editor's styles to set a visible background color for the buttons and ensures the icon color is dark, making the toolbar fully usable in the light theme.