### PR TITLE
Fix: Reduce excessive spacing in article view

### DIFF
--- a/view_article.php
+++ b/view_article.php
@@ -68,9 +68,9 @@ if (!$article_id || $article_id <= 0) {
         .theme-switcher select { margin: 0 0.5rem; padding: 0.25rem 0.5rem; }
         .theme-switcher button { padding: 0.25rem 0.75rem; font-size: 0.8rem; }
         .content-body { line-height: 1.6; white-space: pre-wrap; }
-        .back-link { display: inline-block; margin-bottom: 2rem; }
+        .back-link { display: inline-block; margin-bottom: 1rem; }
         .error { color: #721c24; background-color: #f8d7da; padding: 1rem; border-radius: 4px; }
-        .meta-info { font-size: 0.9em; color: #6c757d; margin-bottom: 1.5rem; border-bottom: 1px solid #dee2e6; padding-bottom: 1rem; }
+        .meta-info { font-size: 0.9em; color: #6c757d; margin-bottom: 1rem; border-bottom: 1px solid #dee2e6; padding-bottom: 0.5rem; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
The user reported that the article view page (`view_article.php`) had too much vertical space between elements, making it look disproportioned.

This change reduces the `margin-bottom` and `padding-bottom` of the `.back-link` and `.meta-info` elements within the inline styles of the `view_article.php` file. This creates a more compact and visually balanced layout as requested.