### PR TITLE
Fix: Adjust content body style in article view

### DIFF
--- a/view_article.php
+++ b/view_article.php
@@ -67,7 +67,7 @@ if (!$article_id || $article_id <= 0) {
         .theme-switcher { display: flex; align-items: center; }
         .theme-switcher select { margin: 0 0.5rem; padding: 0.25rem 0.5rem; }
         .theme-switcher button { padding: 0.25rem 0.75rem; font-size: 0.8rem; }
-        .content-body { line-height: 1.6; white-space: pre-wrap; }
+        .content-body { /* line-height: 1.6; white-space: pre-wrap; */ }
         .back-link { display: inline-block; margin-bottom: 2rem; }
         .error { color: #721c24; background-color: #f8d7da; padding: 1rem; border-radius: 4px; }
         .meta-info { font-size: 0.9em; color: #6c757d; margin-bottom: 1.5rem; border-bottom: 1px solid #dee2e6; padding-bottom: 1rem; }


### PR DESCRIPTION
Based on user feedback, the initial fix for the spacing issue was incorrect. The excessive spacing was caused by `line-height` and `white-space` properties in the `.content-body` class.

This commit addresses the issue by commenting out these properties in the inline style block of `view_article.php`, resulting in a more compact text layout as requested by the user.