### PR TITLE
Feat: Add exercise preview and render interstitial content

### DIFF
--- a/admin_dashboard.php
+++ b/admin_dashboard.php
@@ -139,7 +139,7 @@ try {
 
         <div class="features-menu">
             <a href="admin_dashboard.php" class="active">Articoli</a>
-            <a href="#" class="disabled" title="Prossimamente">Esercizi</a>
+            <a href="manage_exercises.php">Esercizi</a>
             <a href="#" class="disabled" title="Prossimamente">Obiettivi formativi</a>
             <a href="#" class="disabled" title="Prossimamente">Riscontro alunni</a>
             <a href="#" class="disabled" title="Prossimamente">Valutazioni</a>

--- a/ajax_render_exercise.php
+++ b/ajax_render_exercise.php
@@ -1,0 +1,87 @@
+<?php
+// File: ajax_render_exercise.php
+// Purpose: Renders a preview of an exercise from wikitext.
+
+// No session needed for a simple preview, but good practice to keep it
+// in case we want to check for teacher role in the future.
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    http_response_code(403);
+    echo "Forbidden";
+    exit;
+}
+
+require_once 'includes/exercise_parser.php';
+require_once 'includes/Parsedown.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['content'])) {
+    http_response_code(400);
+    echo "Invalid request.";
+    exit;
+}
+
+$wikitext = $_POST['content'];
+
+$parser = new ExerciseParser();
+$Parsedown = new Parsedown();
+$elements = $parser->parse($wikitext);
+
+// --- Rendering Logic ---
+// This could be moved to a helper class/function later to be shared with view_exercise.php
+
+header('Content-Type: text/html');
+
+if (empty($elements)) {
+    echo "<p>No content to preview. Write some text or a question to see a preview.</p>";
+    exit;
+}
+
+foreach ($elements as $element) {
+    if ($element['type'] === 'content') {
+        // Render markdown content to HTML
+        echo '<div class="content-block">';
+        echo $Parsedown->text($element['text']);
+        echo '</div>';
+
+    } elseif ($element['type'] === 'question') {
+        $q = $element['data'];
+        echo '<div class="question-preview">';
+        echo '<p><strong>' . htmlspecialchars($q['order']) . '. ' . htmlspecialchars($q['text']) . '</strong> (' . htmlspecialchars($q['points']) . ' points)</p>';
+
+        switch ($q['type']) {
+            case 'multiple_choice':
+            case 'multiple_response':
+                echo '<ul style="list-style-type: none; padding-left: 20px;">';
+                foreach ($q['options'] as $opt) {
+                    $icon = $q['type'] === 'multiple_choice' ? '&#9675;' : '&#9744;'; // Circle or Checkbox
+                    $style = $opt['is_correct'] ? 'color: green; font-weight: bold;' : '';
+                    echo '<li style="' . $style . '">' . $icon . ' ' . htmlspecialchars($opt['text']) . '</li>';
+                }
+                echo '</ul>';
+                break;
+
+            case 'open_ended':
+                echo '<textarea readonly rows="3" style="width: 90%; background-color: #f8f8f8; border: 1px dashed #ccc;">Student will write their answer here.</textarea>';
+                if ($q['char_limit']) {
+                    echo '<br><small>Character limit: ' . htmlspecialchars($q['char_limit']) . '</small>';
+                }
+                break;
+
+            case 'cloze_test':
+                 echo '<div class="cloze-preview" style="padding-left: 20px;">';
+                 echo '<p><strong>Word List:</strong> ' . implode(', ', array_map('htmlspecialchars', $q['cloze_data']['word_list'])) . '</p>';
+                 echo '<div>' . $Parsedown->text($q['text']) . '</div>'; // Show the text with blanks
+                 echo '<p><strong>Solution:</strong></p>';
+                 echo '<ul>';
+                 foreach ($q['cloze_data']['solution'] as $num => $word) {
+                     echo '<li>[' . htmlspecialchars($num) . ']: ' . htmlspecialchars($word) . '</li>';
+                 }
+                 echo '</ul>';
+                 echo '</div>';
+                 break;
+        }
+        echo '</div>'; // .question-preview
+    }
+    echo '<hr style="border: 0; border-top: 1px dashed #ccc;">';
+}
+?>

--- a/create_exercise.php
+++ b/create_exercise.php
@@ -1,0 +1,198 @@
+<?php
+// File: create_exercise.php
+// Purpose: Handles the creation of a new exercise.
+
+session_start();
+
+// --- Security Check: Ensure user is a logged-in teacher ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    header('Location: login.php');
+    exit;
+}
+
+require_once 'includes/db.php';
+require_once 'includes/theme_manager.php';
+
+$message = '';
+$current_theme = getCurrentTheme($pdo);
+
+// --- Fetch articles to link ---
+try {
+    $stmt = $pdo->query("SELECT id, title FROM articles ORDER BY title ASC");
+    $articles = $stmt->fetchAll();
+} catch (PDOException $e) {
+    $articles = [];
+    $message = '<div class="message error">Could not fetch articles.</div>';
+}
+
+
+require_once 'includes/exercise_parser.php'; // Include the new parser
+
+// --- Handle form submission ---
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title']);
+    $content = $_POST['content'] ?? '';
+    $linked_articles = $_POST['articles'] ?? [];
+    $creator_id = $_SESSION['user_id'];
+
+    $parser = new ExerciseParser();
+    $parsed_questions = $parser->parse($content);
+
+    if (empty($title) || empty($content)) {
+        $message = '<div class="message error">Title and content cannot be empty.</div>';
+    } elseif (empty($parsed_questions)) {
+        $message = '<div class="message error">Content does not contain any valid questions. Please check the syntax.</div>';
+    } else {
+        $pdo->beginTransaction();
+        try {
+            // 1. Create the exercise
+            $stmt = $pdo->prepare("INSERT INTO exercises (title, creator_id, content) VALUES (?, ?, ?)");
+            $stmt->execute([$title, $creator_id, $content]);
+            $exercise_id = $pdo->lastInsertId();
+
+            // 2. Link articles
+            if (!empty($linked_articles)) {
+                $stmt_insert_article = $pdo->prepare("INSERT INTO exercise_articles (exercise_id, article_id) VALUES (?, ?)");
+                foreach ($linked_articles as $article_id) {
+                    $stmt_insert_article->execute([$exercise_id, $article_id]);
+                }
+            }
+
+            // 3. Insert parsed questions and options
+            $stmt_q = $pdo->prepare(
+                "INSERT INTO questions (exercise_id, question_text, question_type, question_order, points, char_limit, cloze_data) VALUES (?, ?, ?, ?, ?, ?, ?)"
+            );
+            $stmt_o = $pdo->prepare(
+                "INSERT INTO question_options (question_id, option_text, score) VALUES (?, ?, ?)"
+            );
+
+            foreach ($parsed_questions as $q) {
+                $cloze_data_json = isset($q['cloze_data']) ? json_encode($q['cloze_data']) : null;
+                $stmt_q->execute([$exercise_id, $q['text'], $q['type'], $q['order'], $q['points'], $q['char_limit'] ?? null, $cloze_data_json]);
+                $question_id = $pdo->lastInsertId();
+
+                if (isset($q['options'])) {
+                    foreach ($q['options'] as $opt) {
+                        $score = $opt['is_correct'] ? $q['points'] : 0;
+                         if ($q['type'] === 'multiple_response' && $opt['is_correct']) {
+                             $score = $q['points'];
+                        }
+                        $stmt_o->execute([$question_id, $opt['text'], $score]);
+                    }
+                }
+            }
+
+            $pdo->commit();
+            $_SESSION['message'] = '<div class="message success">Exercise created successfully!</div>';
+            header('Location: manage_exercises.php');
+            exit;
+
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            $message = '<div class="message error">Failed to create exercise: ' . $e->getMessage() . '</div>';
+        }
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create New Exercise</title>
+    <link rel="stylesheet" href="assets/css/<?php echo $current_theme; ?>-theme.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+    <style>
+        .form-group.required label::after {
+            content: ' *';
+            color: red;
+        }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span>Create New Exercise</span>
+        <a href="manage_exercises.php">Back to Exercise List</a>
+    </div>
+
+    <div class="container">
+        <h1>New Exercise</h1>
+
+        <?php echo $message; ?>
+
+        <form action="create_exercise.php" method="POST" id="exercise-form">
+            <div class="form-group required">
+                <label for="title">Exercise Title</label>
+                <input type="text" id="title" name="title" required>
+            </div>
+
+            <div class="form-group">
+                <label for="articles">Link to Theoretical Articles (Optional)</label>
+                <select id="articles" name="articles[]" multiple size="5">
+                    <?php foreach ($articles as $article): ?>
+                        <option value="<?php echo $article['id']; ?>"><?php echo htmlspecialchars($article['title']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="form-group required">
+                <label for="content">Exercise Content (Wikitext)</label>
+                <textarea id="content" name="content" rows="20"></textarea>
+            </div>
+
+            <hr>
+            <button type="submit">Create Exercise</button>
+            <button type="button" id="preview-btn" style="float: right;">Preview</button>
+        </form>
+
+        <div id="preview-container" style="display: none; margin-top: 2rem; border: 1px solid #ccc; padding: 1rem; background-color: #f9f9f9;">
+            <h2>Preview</h2>
+            <div id="preview-content"></div>
+            <button type="button" id="close-preview-btn" style="margin-top: 1rem;">Close Preview</button>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+    <script>
+        const easyMDE = new EasyMDE({element: document.getElementById('content')});
+
+        const previewBtn = document.getElementById('preview-btn');
+        const closePreviewBtn = document.getElementById('close-preview-btn');
+        const previewContainer = document.getElementById('preview-container');
+        const previewContent = document.getElementById('preview-content');
+
+        previewBtn.addEventListener('click', () => {
+            const wikitext = easyMDE.value();
+
+            previewContent.innerHTML = 'Loading preview...';
+            previewContainer.style.display = 'block';
+
+            fetch('ajax_render_exercise.php', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: 'content=' + encodeURIComponent(wikitext)
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.text();
+            })
+            .then(html => {
+                previewContent.innerHTML = html;
+            })
+            .catch(error => {
+                previewContent.innerHTML = '<p style="color: red;">Error loading preview: ' + error.message + '</p>';
+            });
+        });
+
+        closePreviewBtn.addEventListener('click', () => {
+            previewContainer.style.display = 'none';
+            previewContent.innerHTML = '';
+        });
+    </script>
+</body>
+</html>

--- a/database.sql
+++ b/database.sql
@@ -46,3 +46,78 @@ CREATE TABLE IF NOT EXISTS `user_preferences` (
     `theme` VARCHAR(50) NOT NULL DEFAULT 'light',
     FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- SECTION: Exercises --
+
+-- Table: exercises
+-- Stores the main information about an exercise.
+CREATE TABLE IF NOT EXISTS `exercises` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `title` VARCHAR(255) NOT NULL,
+    `creator_id` INT NOT NULL,
+    `content` TEXT,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (`creator_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: exercise_articles
+-- Links exercises to their prerequisite articles (many-to-many).
+CREATE TABLE IF NOT EXISTS `exercise_articles` (
+    `exercise_id` INT NOT NULL,
+    `article_id` INT NOT NULL,
+    PRIMARY KEY (`exercise_id`, `article_id`),
+    FOREIGN KEY (`exercise_id`) REFERENCES `exercises`(`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`article_id`) REFERENCES `articles`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: questions
+-- Stores individual questions within an exercise.
+CREATE TABLE IF NOT EXISTS `questions` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `exercise_id` INT NOT NULL,
+    `question_text` TEXT NOT NULL,
+    `question_type` ENUM('multiple_choice', 'multiple_response', 'open_ended', 'cloze_test') NOT NULL,
+    `question_order` INT NOT NULL,
+    `points` DECIMAL(5, 2) NOT NULL DEFAULT 0.00,
+    `char_limit` INT DEFAULT NULL,
+    `cloze_data` JSON DEFAULT NULL,
+    FOREIGN KEY (`exercise_id`) REFERENCES `exercises`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: question_options
+-- Stores the options for a multiple-choice question.
+CREATE TABLE IF NOT EXISTS `question_options` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `question_id` INT NOT NULL,
+    `option_text` TEXT NOT NULL,
+    `score` DECIMAL(5, 2) NOT NULL DEFAULT 0.00,
+    FOREIGN KEY (`question_id`) REFERENCES `questions`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: student_submissions
+-- Records a student's attempt to complete an exercise.
+CREATE TABLE IF NOT EXISTS `student_submissions` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `exercise_id` INT NOT NULL,
+    `student_id` INT NOT NULL,
+    `submitted_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `is_graded` BOOLEAN NOT NULL DEFAULT FALSE,
+    FOREIGN KEY (`exercise_id`) REFERENCES `exercises`(`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`student_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,
+    UNIQUE KEY `unique_submission` (`exercise_id`, `student_id`) -- Assuming a student gets one submission per exercise
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: submission_answers
+-- Stores the student's specific answers for a submission.
+CREATE TABLE IF NOT EXISTS `submission_answers` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `submission_id` INT NOT NULL,
+    `question_id` INT NOT NULL,
+    `selected_option_id` INT NULL,
+    `open_ended_answer` TEXT NULL,
+    `assigned_score` DECIMAL(5, 2) NULL, -- Final score determined by the teacher
+    FOREIGN KEY (`submission_id`) REFERENCES `student_submissions`(`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`question_id`) REFERENCES `questions`(`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`selected_option_id`) REFERENCES `question_options`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/delete_exercise.php
+++ b/delete_exercise.php
@@ -1,0 +1,50 @@
+<?php
+// File: delete_exercise.php
+// Purpose: Handles the deletion of an exercise.
+
+session_start();
+
+// --- Security Check: Ensure user is a logged-in teacher ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    header('Location: login.php');
+    exit;
+}
+
+require_once 'includes/db.php';
+
+// Get the exercise ID from the URL and validate it
+$exercise_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+
+if (!$exercise_id || $exercise_id <= 0) {
+    // Invalid ID, redirect back to the management page with an error message
+    $_SESSION['message'] = '<div class="message error">Invalid exercise ID.</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+try {
+    // The ON DELETE CASCADE constraint on the 'questions' and other related tables
+    // will handle deleting all associated data (questions, options, submissions, etc.).
+    $stmt = $pdo->prepare("DELETE FROM exercises WHERE id = ?");
+
+    if ($stmt->execute([$exercise_id])) {
+        if ($stmt->rowCount() > 0) {
+            // Deletion was successful
+            $_SESSION['message'] = '<div class="message success">Exercise and all its related data have been deleted successfully.</div>';
+        } else {
+            // No rows were affected, meaning the exercise ID did not exist
+            $_SESSION['message'] = '<div class="message error">Exercise not found or already deleted.</div>';
+        }
+    } else {
+        // The query failed to execute
+        $_SESSION['message'] = '<div class="message error">Failed to delete exercise.</div>';
+    }
+} catch (PDOException $e) {
+    // Handle database errors
+    $_SESSION['message'] = '<div class="message error">Database error: ' . $e->getMessage() . '</div>';
+}
+
+// Redirect back to the exercise management page
+header('Location: manage_exercises.php');
+exit;
+?>

--- a/edit_exercise.php
+++ b/edit_exercise.php
@@ -1,0 +1,224 @@
+<?php
+// File: edit_exercise.php
+// Purpose: Handles editing an existing exercise.
+
+session_start();
+
+// --- Security Check & Includes ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    header('Location: login.php');
+    exit;
+}
+require_once 'includes/db.php';
+require_once 'includes/theme_manager.php';
+
+$message = '';
+$current_theme = getCurrentTheme($pdo);
+$exercise_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+
+if (!$exercise_id) {
+    $_SESSION['message'] = '<div class="message error">Invalid exercise ID.</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+require_once 'includes/exercise_parser.php'; // Include the new parser
+
+// --- Handle form submission for updating ---
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title']);
+    $content = $_POST['content'] ?? '';
+    $linked_articles = $_POST['articles'] ?? [];
+
+    $parser = new ExerciseParser();
+    $parsed_questions = $parser->parse($content);
+
+    if (empty($title) || empty($content)) {
+        $message = '<div class="message error">Title and content cannot be empty.</div>';
+    } elseif (empty($parsed_questions)) {
+        $message = '<div class="message error">Content does not contain any valid questions. Please check the syntax.</div>';
+    } else {
+        $pdo->beginTransaction();
+        try {
+            // 1. Update exercise title and content
+            $stmt = $pdo->prepare("UPDATE exercises SET title = ?, content = ? WHERE id = ?");
+            $stmt->execute([$title, $content, $exercise_id]);
+
+            // 2. Update linked articles
+            $stmt = $pdo->prepare("DELETE FROM exercise_articles WHERE exercise_id = ?");
+            $stmt->execute([$exercise_id]);
+            if (!empty($linked_articles)) {
+                $stmt_insert_article = $pdo->prepare("INSERT INTO exercise_articles (exercise_id, article_id) VALUES (?, ?)");
+                foreach ($linked_articles as $article_id) {
+                    $stmt_insert_article->execute([$exercise_id, $article_id]);
+                }
+            }
+
+            // 3. Delete old questions and options
+            $stmt = $pdo->prepare("DELETE FROM questions WHERE exercise_id = ?");
+            $stmt->execute([$exercise_id]);
+
+            // 4. Insert newly parsed questions and options
+            $stmt_q = $pdo->prepare(
+                "INSERT INTO questions (exercise_id, question_text, question_type, question_order, points, char_limit, cloze_data) VALUES (?, ?, ?, ?, ?, ?, ?)"
+            );
+            $stmt_o = $pdo->prepare(
+                "INSERT INTO question_options (question_id, option_text, score) VALUES (?, ?, ?)"
+            );
+
+            foreach ($parsed_questions as $q) {
+                $cloze_data_json = isset($q['cloze_data']) ? json_encode($q['cloze_data']) : null;
+                $stmt_q->execute([$exercise_id, $q['text'], $q['type'], $q['order'], $q['points'], $q['char_limit'] ?? null, $cloze_data_json]);
+                $question_id = $pdo->lastInsertId();
+
+                if (isset($q['options'])) {
+                    foreach ($q['options'] as $opt) {
+                        $score = $opt['is_correct'] ? $q['points'] : 0;
+                        if ($q['type'] === 'multiple_response' && $opt['is_correct']) {
+                             // For multi-response, distribute points or handle as needed. Here, we'll just assign full points.
+                             $score = $q['points'];
+                        }
+                        $stmt_o->execute([$question_id, $opt['text'], $score]);
+                    }
+                }
+            }
+
+            $pdo->commit();
+            $_SESSION['message'] = '<div class="message success">Exercise updated successfully!</div>';
+            header('Location: manage_exercises.php');
+            exit;
+
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            $message = '<div class="message error">Failed to update exercise: ' . $e->getMessage() . '</div>';
+        }
+    }
+}
+
+
+// --- Fetch existing exercise data to pre-fill the form ---
+try {
+    // Fetch exercise details
+    $stmt = $pdo->prepare("SELECT title, content FROM exercises WHERE id = ?");
+    $stmt->execute([$exercise_id]);
+    $exercise = $stmt->fetch();
+    if (!$exercise) {
+        throw new Exception("Exercise not found.");
+    }
+
+    // Fetch linked articles
+    $stmt = $pdo->prepare("SELECT article_id FROM exercise_articles WHERE exercise_id = ?");
+    $stmt->execute([$exercise_id]);
+    $selected_articles = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+
+    // Fetch all articles for the select box
+    $stmt = $pdo->query("SELECT id, title FROM articles ORDER BY title ASC");
+    $all_articles = $stmt->fetchAll();
+
+} catch (Exception $e) {
+    $_SESSION['message'] = '<div class="message error">' . $e->getMessage() . '</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Exercise</title>
+    <link rel="stylesheet" href="assets/css/<?php echo $current_theme; ?>-theme.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+    <style>
+        .form-group.required label::after { content: ' *'; color: red; }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span>Edit Exercise</span>
+        <a href="manage_exercises.php">Back to Exercise List</a>
+    </div>
+
+    <div class="container">
+        <h1>Edit Exercise: <?php echo htmlspecialchars($exercise['title']); ?></h1>
+        <?php echo $message; ?>
+
+        <form action="edit_exercise.php?id=<?php echo $exercise_id; ?>" method="POST">
+            <div class="form-group required">
+                <label for="title">Exercise Title</label>
+                <input type="text" id="title" name="title" value="<?php echo htmlspecialchars($exercise['title']); ?>" required>
+            </div>
+
+            <div class="form-group">
+                <label for="articles">Link to Theoretical Articles (Optional)</label>
+                <select id="articles" name="articles[]" multiple size="5">
+                    <?php foreach ($all_articles as $article): ?>
+                        <option value="<?php echo $article['id']; ?>" <?php echo in_array($article['id'], $selected_articles) ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($article['title']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="form-group required">
+                <label for="content">Exercise Content (Wikitext)</label>
+                <textarea id="content" name="content" rows="20"><?php echo htmlspecialchars($exercise['content'] ?? ''); ?></textarea>
+            </div>
+
+            <hr>
+            <button type="submit">Save Changes</button>
+            <button type="button" id="preview-btn" style="float: right;">Preview</button>
+        </form>
+
+        <div id="preview-container" style="display: none; margin-top: 2rem; border: 1px solid #ccc; padding: 1rem; background-color: #f9f9f9;">
+            <h2>Preview</h2>
+            <div id="preview-content"></div>
+            <button type="button" id="close-preview-btn" style="margin-top: 1rem;">Close Preview</button>
+        </div>
+    </div>
+
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script>
+    const easyMDE = new EasyMDE({element: document.getElementById('content')});
+
+    const previewBtn = document.getElementById('preview-btn');
+    const closePreviewBtn = document.getElementById('close-preview-btn');
+    const previewContainer = document.getElementById('preview-container');
+    const previewContent = document.getElementById('preview-content');
+
+    previewBtn.addEventListener('click', () => {
+        const wikitext = easyMDE.value();
+
+        previewContent.innerHTML = 'Loading preview...';
+        previewContainer.style.display = 'block';
+
+        fetch('ajax_render_exercise.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: 'content=' + encodeURIComponent(wikitext)
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.text();
+        })
+        .then(html => {
+            previewContent.innerHTML = html;
+        })
+        .catch(error => {
+            previewContent.innerHTML = '<p style="color: red;">Error loading preview: ' + error.message + '</p>';
+        });
+    });
+
+    closePreviewBtn.addEventListener('click', () => {
+        previewContainer.style.display = 'none';
+        previewContent.innerHTML = '';
+    });
+</script>
+</body>
+</html>

--- a/grade_exercise.php
+++ b/grade_exercise.php
@@ -1,0 +1,197 @@
+<?php
+// File: grade_exercise.php
+// Purpose: The actual grading interface for a single submission.
+
+session_start();
+
+// --- Security & Initialization ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    header('Location: login.php');
+    exit;
+}
+require_once 'includes/db.php';
+require_once 'includes/theme_manager.php';
+
+$current_theme = getCurrentTheme($pdo);
+$submission_id = filter_input(INPUT_GET, 'submission_id', FILTER_VALIDATE_INT);
+$message = '';
+
+if (!$submission_id) {
+    $_SESSION['message'] = '<div class="message error">Invalid submission ID.</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+// --- Handle Grade Submission ---
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['grades'])) {
+    $grades = $_POST['grades'];
+    $pdo->beginTransaction();
+    try {
+        foreach ($grades as $answer_id => $score) {
+            $stmt = $pdo->prepare("UPDATE submission_answers SET assigned_score = ? WHERE id = ?");
+            // Allow null scores for ungraded open questions
+            $score_value = $score === '' ? null : (float)$score;
+            $stmt->execute([$score_value, (int)$answer_id]);
+        }
+
+        // Mark the entire submission as graded
+        $stmt_mark = $pdo->prepare("UPDATE student_submissions SET is_graded = 1 WHERE id = ?");
+        $stmt_mark->execute([$submission_id]);
+
+        $pdo->commit();
+        $message = '<div class="message success">Grades saved successfully!</div>';
+
+    } catch (Exception $e) {
+        $pdo->rollBack();
+        $message = '<div class="message error">Failed to save grades: ' . $e->getMessage() . '</div>';
+    }
+}
+
+
+// --- Fetch all data for the grading view ---
+try {
+    // Get submission info (exercise id, student name)
+    $sql_info = "SELECT s.exercise_id, u.username FROM student_submissions s JOIN users u ON s.student_id = u.id WHERE s.id = ?";
+    $stmt_info = $pdo->prepare($sql_info);
+    $stmt_info->execute([$submission_id]);
+    $submission_info = $stmt_info->fetch();
+    if (!$submission_info) throw new Exception("Submission not found.");
+
+    $exercise_id = $submission_info['exercise_id'];
+
+    // Get all questions for the exercise
+    $sql_q = "SELECT * FROM questions WHERE exercise_id = ? ORDER BY question_order ASC";
+    $stmt_q = $pdo->prepare($sql_q);
+    $stmt_q->execute([$exercise_id]);
+    $questions = $stmt_q->fetchAll(PDO::FETCH_ASSOC);
+
+    // For each question, get the student's answer(s) and related data
+    foreach ($questions as $key => $q) {
+        $sql_a = "SELECT * FROM submission_answers WHERE submission_id = ? AND question_id = ?";
+        $stmt_a = $pdo->prepare($sql_a);
+        $stmt_a->execute([$submission_id, $q['id']]);
+        $student_answers = $stmt_a->fetchAll(PDO::FETCH_ASSOC);
+        $questions[$key]['student_answers'] = $student_answers;
+
+        $auto_score = 0;
+
+        if ($q['question_type'] == 'multiple_choice' || $q['question_type'] == 'multiple_response') {
+            $sql_o = "SELECT * FROM question_options WHERE question_id = ?";
+            $stmt_o = $pdo->prepare($sql_o);
+            $stmt_o->execute([$q['id']]);
+            $options = $stmt_o->fetchAll(PDO::FETCH_ASSOC);
+            $questions[$key]['options'] = $options;
+
+            $selected_option_ids = array_column($student_answers, 'selected_option_id');
+            foreach($options as $option) {
+                if (in_array($option['id'], $selected_option_ids)) {
+                    $auto_score += $option['score'];
+                }
+            }
+        } elseif ($q['question_type'] == 'cloze_test') {
+            $cloze_data = json_decode($q['cloze_data'], true);
+            $student_cloze_answers = json_decode($student_answers[0]['open_ended_answer'], true);
+            $questions[$key]['cloze_data'] = $cloze_data;
+            $questions[$key]['student_cloze_answers'] = $student_cloze_answers;
+
+            $points_per_blank = $q['points'] / count($cloze_data['solution']);
+            foreach($cloze_data['solution'] as $blank_num => $correct_word) {
+                if (isset($student_cloze_answers[$blank_num]) && strcasecmp(trim($student_cloze_answers[$blank_num]), trim($correct_word)) == 0) {
+                    $auto_score += $points_per_blank;
+                }
+            }
+        }
+        $questions[$key]['auto_score'] = $auto_score;
+    }
+
+} catch (Exception $e) {
+    $_SESSION['message'] = '<div class="message error">' . $e->getMessage() . '</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grade Submission for <?php echo htmlspecialchars($submission_info['username']); ?></title>
+    <link rel="stylesheet" href="assets/css/<?php echo $current_theme; ?>-theme.css">
+    <style>
+        .question-grade { border: 1px solid #ddd; padding: 1rem; margin-bottom: 1.5rem; border-radius: 5px; }
+        .student-answer { background-color: #f0f8ff; padding: 0.75rem; border-radius: 4px; margin-top: 0.5rem; }
+        .option-item.correct { color: green; font-weight: bold; }
+        .option-item.incorrect { color: red; }
+        .option-item.selected::before { content: '▶ '; }
+        .score-input { width: 100px; padding: 0.5rem; }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span>Grading: <?php echo htmlspecialchars($submission_info['username']); ?></span>
+        <a href="grade_submission.php?exercise_id=<?php echo $exercise_id; ?>">Back to Submissions</a>
+    </div>
+
+    <div class="container">
+        <h1>Grade Submission</h1>
+        <?php echo $message; ?>
+
+        <form method="POST" action="grade_exercise.php?submission_id=<?php echo $submission_id; ?>">
+            <?php foreach ($questions as $q): ?>
+                <div class="question-grade">
+                    <h4><?php echo $q['question_order']; ?>. <?php echo htmlspecialchars($q['question_text']); ?></h4>
+                    <div class="student-answer">
+                        <strong>Student's Answer:</strong>
+                        <?php if ($q['question_type'] == 'multiple_choice' || $q['question_type'] == 'multiple_response'): ?>
+                            <ul>
+                            <?php
+                            $selected_ids = array_column($q['student_answers'], 'selected_option_id');
+                            foreach ($q['options'] as $opt):
+                                $is_selected = in_array($opt['id'], $selected_ids);
+                                $class = $is_selected ? 'selected' : '';
+                                if ($is_selected) {
+                                    $class .= ($opt['score'] > 0) ? ' correct' : ' incorrect';
+                                }
+                            ?>
+                                <li class="option-item <?php echo $class; ?>">
+                                    <?php echo htmlspecialchars($opt['option_text']); ?> (Points for this option: <?php echo $opt['score']; ?>)
+                                </li>
+                            <?php endforeach; ?>
+                            </ul>
+                        <?php elseif ($q['question_type'] == 'cloze_test'): ?>
+                            <ul>
+                                <?php foreach($q['cloze_data']['solution'] as $blank_num => $correct_word):
+                                    $student_word = $q['student_cloze_answers'][$blank_num] ?? '[No Answer]';
+                                    $is_correct = (strcasecmp(trim($student_word), trim($correct_word)) == 0);
+                                ?>
+                                    <li class="<?php echo $is_correct ? 'correct' : 'incorrect'; ?>">
+                                        Blank [<?php echo $blank_num; ?>]:
+                                        Student wrote "<?php echo htmlspecialchars($student_word); ?>".
+                                        Correct answer was "<?php echo htmlspecialchars($correct_word); ?>".
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php else: // open_ended ?>
+                            <p><?php echo nl2br(htmlspecialchars($q['student_answers'][0]['open_ended_answer'])); ?></p>
+                        <?php endif; ?>
+                    </div>
+
+                    <p><strong>Auto-calculated Score:</strong> <?php echo number_format($q['auto_score'], 2); ?></p>
+
+                    <div class="form-group">
+                        <label for="grade-<?php echo $q['student_answers'][0]['id']; ?>"><strong>Assigned Score:</strong></label>
+                        <input type="number" step="0.01" class="score-input"
+                               name="grades[<?php echo $q['student_answers'][0]['id']; ?>]"
+                               id="grade-<?php echo $q['student_answers'][0]['id']; ?>"
+                               value="<?php echo $q['student_answers'][0]['assigned_score'] ?? ($q['question_type'] == 'multiple_choice' ? $q['auto_score'] : ''); ?>"
+                               placeholder="Enter score">
+                    </div>
+                </div>
+            <?php endforeach; ?>
+
+            <button type="submit" name="submit_grades">Save Grades</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/grade_submission.php
+++ b/grade_submission.php
@@ -1,0 +1,123 @@
+<?php
+// File: grade_submission.php
+// Purpose: Allows a teacher to view and grade student submissions for an exercise.
+
+session_start();
+
+// --- Security & Initialization ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    header('Location: login.php');
+    exit;
+}
+require_once 'includes/db.php';
+require_once 'includes/theme_manager.php';
+
+$current_theme = getCurrentTheme($pdo);
+$exercise_id = filter_input(INPUT_GET, 'exercise_id', FILTER_VALIDATE_INT);
+
+if (!$exercise_id) {
+    $_SESSION['message'] = '<div class="message error">Invalid exercise ID.</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+// --- Fetch exercise title ---
+try {
+    $stmt = $pdo->prepare("SELECT title FROM exercises WHERE id = ?");
+    $stmt->execute([$exercise_id]);
+    $exercise = $stmt->fetch();
+    if (!$exercise) {
+        throw new Exception("Exercise not found.");
+    }
+} catch (Exception $e) {
+    $_SESSION['message'] = '<div class="message error">' . $e->getMessage() . '</div>';
+    header('Location: manage_exercises.php');
+    exit;
+}
+
+// --- Fetch submissions for this exercise ---
+try {
+    $sql = "
+        SELECT
+            ss.id AS submission_id,
+            ss.submitted_at,
+            ss.is_graded,
+            u.username,
+            u.id AS student_id,
+            (SELECT SUM(sa.assigned_score) FROM submission_answers sa WHERE sa.submission_id = ss.id) AS total_score
+        FROM student_submissions ss
+        JOIN users u ON ss.student_id = u.id
+        WHERE ss.exercise_id = ?
+        ORDER BY ss.submitted_at DESC
+    ";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$exercise_id]);
+    $submissions = $stmt->fetchAll();
+} catch (PDOException $e) {
+    $submissions = [];
+    $message = '<div class="message error">Could not fetch submissions: ' . $e->getMessage() . '</div>';
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Submissions for <?php echo htmlspecialchars($exercise['title']); ?></title>
+    <link rel="stylesheet" href="assets/css/<?php echo $current_theme; ?>-theme.css">
+    <style>
+        .submission-list { list-style-type: none; padding: 0; }
+        .submission-item { display: flex; justify-content: space-between; align-items: center; padding: 0.75rem; border-bottom: 1px solid #ccc; }
+        .submission-info { flex-grow: 1; }
+        .grade-status { font-style: italic; color: #6c757d; }
+        .grade-status.graded { color: #28a745; }
+        .btn-grade {
+            text-decoration: none;
+            padding: 0.4rem 0.8rem;
+            color: white;
+            background-color: #007bff;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span>Grading Area</span>
+        <a href="manage_exercises.php">Back to Exercise List</a>
+    </div>
+
+    <div class="container">
+        <h1>Submissions for: <?php echo htmlspecialchars($exercise['title']); ?></h1>
+
+        <?php if (isset($message)) echo $message; ?>
+
+        <?php if (empty($submissions)): ?>
+            <p>No submissions have been made for this exercise yet.</p>
+        <?php else: ?>
+            <ul class="submission-list">
+                <?php foreach ($submissions as $sub): ?>
+                    <li class="submission-item">
+                        <div class="submission-info">
+                            <strong><?php echo htmlspecialchars($sub['username']); ?></strong>
+                            <small>(Submitted: <?php echo date('Y-m-d H:i', strtotime($sub['submitted_at'])); ?>)</small>
+                            <br>
+                            <span class="grade-status <?php echo $sub['is_graded'] ? 'graded' : ''; ?>">
+                                <?php echo $sub['is_graded'] ? 'Graded' : 'Not Graded'; ?>
+                            </span>
+                            <?php if ($sub['is_graded']): ?>
+                                <span> - Score: <?php echo number_format($sub['total_score'], 2); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="submission-actions">
+                            <a href="grade_exercise.php?submission_id=<?php echo $sub['submission_id']; ?>" class="btn-grade">
+                                <?php echo $sub['is_graded'] ? 'View/Edit Grade' : 'Grade Now'; ?>
+                            </a>
+                        </div>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/includes/exercise_parser.php
+++ b/includes/exercise_parser.php
@@ -1,0 +1,178 @@
+<?php
+
+class ExerciseParser {
+
+    /**
+     * Parses the wikitext of an exercise into a structured array of elements,
+     * which can be either questions or content blocks.
+     *
+     * @param string $wikitext The raw text content of the exercise.
+     * @return array A structured array of mixed content and question elements.
+     */
+    public function parse(string $wikitext): array {
+        $elements = [];
+        $question_order = 1;
+        $last_pos = 0;
+
+        // Find all question tags and their positions
+        preg_match_all(
+            '/\[\[(DOMANDA|DOMANDA_MULTI-RISPOSTA|DOMANDA_APERTA|COMPLETAMENTO_TESTO)\]\]/',
+            $wikitext,
+            $matches,
+            PREG_OFFSET_CAPTURE
+        );
+
+        foreach ($matches[0] as $index => $match) {
+            $tag_full = $match[0]; // e.g., "[[DOMANDA]]"
+            $tag_start_pos = $match[1];
+            $tag_name = $matches[1][$index][0]; // e.g., "DOMANDA"
+
+            // 1. Capture interstitial content before the current tag
+            if ($tag_start_pos > $last_pos) {
+                $content_text = trim(substr($wikitext, $last_pos, $tag_start_pos - $last_pos));
+                if (!empty($content_text)) {
+                    $elements[] = ['type' => 'content', 'text' => $content_text];
+                }
+            }
+
+            // 2. Determine the content of the current question block
+            $next_tag_start_pos = $matches[0][$index + 1][1] ?? strlen($wikitext);
+            $question_block_content = substr($wikitext, $tag_start_pos, $next_tag_start_pos - $tag_start_pos);
+
+            // 3. Parse the question block
+            $parsed_question = null;
+            $question_text_without_tag = substr($question_block_content, strlen($tag_full));
+
+            switch ($tag_name) {
+                case 'DOMANDA':
+                    $parsed_question = $this->parseMultipleChoice($question_text_without_tag, false);
+                    break;
+                case 'DOMANDA_MULTI-RISPOSTA':
+                    $parsed_question = $this->parseMultipleChoice($question_text_without_tag, true);
+                    break;
+                case 'DOMANDA_APERTA':
+                    $parsed_question = $this->parseOpenEnded($question_text_without_tag);
+                    break;
+                case 'COMPLETAMENTO_TESTO':
+                    $parsed_question = $this->parseClozeTest($question_text_without_tag);
+                    break;
+            }
+
+            if ($parsed_question) {
+                $parsed_question['order'] = $question_order++;
+                $elements[] = ['type' => 'question', 'data' => $parsed_question];
+            }
+
+            $last_pos = $next_tag_start_pos;
+        }
+
+        // 4. Capture any trailing content after the last question
+        if ($last_pos < strlen($wikitext)) {
+            $trailing_content = trim(substr($wikitext, $last_pos));
+            if (!empty($trailing_content)) {
+                $elements[] = ['type' => 'content', 'text' => $trailing_content];
+            }
+        }
+
+        return $elements;
+    }
+
+    private function parseMultipleChoice(string $content, bool $is_multi_response): ?array {
+        $question = [
+            'type' => $is_multi_response ? 'multiple_response' : 'multiple_choice',
+            'text' => '',
+            'points' => 0,
+            'options' => []
+        ];
+
+        // Extract question text (first line after the tag)
+        $lines = explode("\n", trim($content));
+        $question['text'] = trim(array_shift($lines));
+
+        // Extract points
+        preg_match('/\[\[PUNTI\]\]\s*(\d+)/', $content, $points_match);
+        $question['points'] = isset($points_match[1]) ? (int)$points_match[1] : 0;
+
+        // Extract options
+        $options_text = [];
+        foreach ($lines as $line) {
+            if (preg_match('/^\s*\*\s*([A-Z])\)\s*(.*)/', $line, $match)) {
+                $options_text[$match[1]] = trim($match[2]);
+            }
+        }
+
+        // Extract correct answer(s)
+        $correct_answers = [];
+        $correct_tag = $is_multi_response ? 'RISPOSTE_CORRETTE' : 'RISPOSTA_CORRETTA';
+        if (preg_match('/\[\[' . $correct_tag . '\]\]\s*([A-Z,\s]+)/', $content, $answer_match)) {
+            $correct_answers = array_map('trim', explode(',', $answer_match[1]));
+        }
+
+        if (empty($options_text) || empty($correct_answers)) return null;
+
+        foreach ($options_text as $letter => $text) {
+            $question['options'][] = [
+                'text' => $letter . ') ' . $text,
+                'is_correct' => in_array($letter, $correct_answers)
+            ];
+        }
+
+        return $question;
+    }
+
+    private function parseOpenEnded(string $content): ?array {
+        $question = [
+            'type' => 'open_ended',
+            'text' => '',
+            'points' => 0,
+            'char_limit' => null
+        ];
+
+        $lines = explode("\n", trim($content));
+        $question['text'] = trim(array_shift($lines));
+
+        preg_match('/\[\[PUNTI\]\]\s*(\d+)/', $content, $points_match);
+        $question['points'] = isset($points_match[1]) ? (int)$points_match[1] : 0;
+
+        preg_match('/\[\[LIMITE_CARATTERI\]\]\s*(\d+)/', $content, $limit_match);
+        $question['char_limit'] = isset($limit_match[1]) ? (int)$limit_match[1] : null;
+
+        if (empty($question['text'])) return null;
+
+        return $question;
+    }
+
+    private function parseClozeTest(string $content): ?array {
+        $question = [
+            'type' => 'cloze_test',
+            'text' => '',
+            'points' => 0,
+            'cloze_data' => ['word_list' => [], 'solution' => []]
+        ];
+
+        preg_match('/\[\[PUNTI\]\]\s*(\d+)/', $content, $points_match);
+        $question['points'] = isset($points_match[1]) ? (int)$points_match[1] : 0;
+
+        preg_match('/\[\[TESTO\]\]\s*(.*?)\s*\[\[ELENCO_PAROLE\]\]/s', $content, $text_match);
+        $question['text'] = isset($text_match[1]) ? trim($text_match[1]) : '';
+
+        preg_match('/\[\[ELENCO_PAROLE\]\]\s*(.*?)\s*\[\[SOLUZIONE\]\]/s', $content, $words_match);
+        if(isset($words_match[1])) {
+            $question['cloze_data']['word_list'] = array_map('trim', explode(',', trim($words_match[1])));
+        }
+
+        preg_match('/\[\[SOLUZIONE\]\]\s*(.*)/s', $content, $solution_match);
+        if(isset($solution_match[1])) {
+            $solution_lines = explode("\n", trim($solution_match[1]));
+            foreach ($solution_lines as $line) {
+                if(preg_match('/(\d+):\s*(.*)/', $line, $line_match)) {
+                    $question['cloze_data']['solution'][trim($line_match[1])] = trim($line_match[2]);
+                }
+            }
+        }
+
+        if (empty($question['text']) || empty($question['cloze_data']['word_list']) || empty($question['cloze_data']['solution'])) return null;
+
+        return $question;
+    }
+}

--- a/manage_exercises.php
+++ b/manage_exercises.php
@@ -1,0 +1,141 @@
+<?php
+// File: manage_exercises.php
+// Purpose: Dashboard for managing exercises.
+
+session_start();
+
+// --- Authentication and Authorization Check ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'teacher') {
+    header('Location: login.php');
+    exit;
+}
+
+// --- Includes ---
+require_once 'includes/db.php';
+require_once 'includes/theme_manager.php';
+
+// --- Logic ---
+$username = htmlspecialchars($_SESSION['username']);
+$current_theme = getCurrentTheme($pdo);
+
+// Fetch all exercises from the database
+try {
+    $stmt = $pdo->query("SELECT id, title, created_at FROM exercises ORDER BY created_at DESC");
+    $exercises = $stmt->fetchAll();
+} catch (PDOException $e) {
+    $exercises = [];
+    $message = '<div class="message error">Could not fetch exercises: ' . $e->getMessage() . '</div>';
+}
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manage Exercises</title>
+    <link rel="stylesheet" href="assets/css/<?php echo $current_theme; ?>-theme.css">
+    <style>
+        .theme-switcher { display: flex; align-items: center; }
+        .theme-switcher select { margin: 0 0.5rem; padding: 0.25rem 0.5rem; }
+        .navbar-right { display: flex; align-items: center; gap: 1rem; }
+        .item-list li { display: flex; justify-content: space-between; align-items: center; padding: 0.75rem; border-bottom: 1px solid #dee2e6; }
+        .item-info a { font-weight: bold; text-decoration: none; color: inherit; }
+        .item-info small { display: block; color: #6c757d; margin-top: 4px; }
+        .item-actions a, .btn-create {
+            display: inline-block;
+            padding: 0.4rem 0.8rem;
+            border-radius: 4px;
+            text-decoration: none;
+            color: white;
+            font-size: 0.9rem;
+            margin-left: 0.5rem;
+        }
+        .btn-create { background-color: #28a745; margin-bottom: 1.5rem; }
+        .btn-edit { background-color: #ffc107; }
+        .btn-delete { background-color: #dc3545; }
+        .btn-submissions { background-color: #17a2b8; }
+
+        .features-menu {
+            display: flex;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+            border-bottom: 2px solid #dee2e6;
+            padding-bottom: 1rem;
+        }
+        .features-menu a {
+            text-decoration: none;
+            padding: 0.5rem 1rem;
+            border-radius: 5px 5px 0 0;
+            color: #495057;
+            font-weight: 500;
+        }
+        .features-menu a.active {
+            border-bottom: 2px solid #007bff;
+            color: #007bff;
+        }
+        .features-menu a.disabled {
+            color: #6c757d;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span>Welcome, <?php echo $username; ?>! (Teacher)</span>
+        <div class="navbar-right">
+             <a href="admin_dashboard.php">Back to Dashboard</a>
+             <a href="profile.php">Profile</a>
+             <a href="logout.php">Logout</a>
+        </div>
+    </div>
+
+    <div class="container">
+        <h1>Exercise Management</h1>
+
+        <div class="features-menu">
+            <a href="admin_dashboard.php">Articoli</a>
+            <a href="manage_exercises.php" class="active">Esercizi</a>
+            <a href="#" class="disabled" title="Prossimamente">Obiettivi formativi</a>
+            <a href="#" class="disabled" title="Prossimamente">Riscontro alunni</a>
+            <a href="#" class="disabled" title="Prossimamente">Valutazioni</a>
+        </div>
+
+        <?php
+        if (isset($_SESSION['message'])) {
+            echo $_SESSION['message'];
+            unset($_SESSION['message']);
+        }
+        if (isset($message)) {
+            echo $message;
+        }
+        ?>
+
+        <a href="create_exercise.php" class="btn-create">Create New Exercise</a>
+
+        <div class="list-container">
+            <h2>Existing Exercises</h2>
+            <?php if (empty($exercises)): ?>
+                <p>No exercises have been created yet.</p>
+            <?php else: ?>
+                <ul class="item-list">
+                    <?php foreach ($exercises as $exercise): ?>
+                        <li>
+                            <div class="item-info">
+                                <span><?php echo htmlspecialchars($exercise['title']); ?></span>
+                                <small>Created: <?php echo date('Y-m-d', strtotime($exercise['created_at'])); ?></small>
+                            </div>
+                            <div class="item-actions">
+                                <a href="grade_submission.php?exercise_id=<?php echo $exercise['id']; ?>" class="btn-submissions">View Submissions</a>
+                                <a href="edit_exercise.php?id=<?php echo $exercise['id']; ?>" class="btn-edit">Edit</a>
+                                <a href="delete_exercise.php?id=<?php echo $exercise['id']; ?>" class="btn-delete" onclick="return confirm('Are you sure you want to delete this exercise and all its questions and submissions?');">Delete</a>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </div>
+    </div>
+</body>
+</html>

--- a/view_exercise.php
+++ b/view_exercise.php
@@ -1,0 +1,205 @@
+<?php
+// File: view_exercise.php
+// Purpose: Allows a student to view and complete an exercise.
+
+session_start();
+
+// --- Security & Initialization ---
+if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'student') {
+    header('Location: login.php');
+    exit;
+}
+require_once 'includes/db.php';
+require_once 'includes/theme_manager.php';
+
+$message = '';
+$current_theme = getCurrentTheme($pdo);
+$exercise_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$student_id = $_SESSION['user_id'];
+
+if (!$exercise_id) {
+    $_SESSION['message'] = '<div class="message error">Invalid exercise ID.</div>';
+    header('Location: student_dashboard.php');
+    exit;
+}
+
+// --- Check for prior submission ---
+try {
+    $stmt = $pdo->prepare("SELECT id FROM student_submissions WHERE exercise_id = ? AND student_id = ?");
+    $stmt->execute([$exercise_id, $student_id]);
+    if ($stmt->fetch()) {
+        $_SESSION['message'] = '<div class="message info">You have already completed this exercise.</div>';
+        header('Location: student_dashboard.php');
+        exit;
+    }
+} catch (PDOException $e) {
+    $message = '<div class="message error">Database error checking submission status.</div>';
+}
+
+// --- Handle form submission ---
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $answers = $_POST['answers'] ?? [];
+
+    $pdo->beginTransaction();
+    try {
+        // 1. Create a submission record
+        $stmt = $pdo->prepare("INSERT INTO student_submissions (exercise_id, student_id) VALUES (?, ?)");
+        $stmt->execute([$exercise_id, $student_id]);
+        $submission_id = $pdo->lastInsertId();
+
+        // 2. Insert each answer
+        foreach ($answers as $question_id => $answer) {
+            $stmt_insert = $pdo->prepare(
+                "INSERT INTO submission_answers (submission_id, question_id, selected_option_id, open_ended_answer) VALUES (?, ?, ?, ?)"
+            );
+
+            if (is_array($answer)) {
+                // Check if it's an associative array (cloze test) or a simple array (multiple response)
+                if (array_keys($answer) !== range(0, count($answer) - 1)) {
+                    // Cloze test answers, store as JSON
+                    $cloze_answer_json = json_encode($answer);
+                    $stmt_insert->execute([$submission_id, $question_id, null, $cloze_answer_json]);
+                } else {
+                    // Multiple response answers
+                    foreach($answer as $option_id) {
+                        $stmt_insert->execute([$submission_id, $question_id, $option_id, null]);
+                    }
+                }
+            } elseif (is_numeric($answer)) { // Radio button for single option
+                 $stmt_insert->execute([$submission_id, $question_id, $answer, null]);
+            } else { // Textarea for open-ended
+                 $stmt_insert->execute([$submission_id, $question_id, null, trim($answer)]);
+            }
+        }
+
+        $pdo->commit();
+        $_SESSION['message'] = '<div class="message success">Exercise submitted successfully!</div>';
+        header('Location: student_dashboard.php');
+        exit;
+
+    } catch (Exception $e) {
+        $pdo->rollBack();
+        $message = '<div class="message error">Failed to submit exercise: ' . $e->getMessage() . '</div>';
+    }
+}
+
+
+// --- Fetch exercise data for viewing ---
+require_once 'includes/exercise_parser.php';
+require_once 'includes/Parsedown.php';
+
+try {
+    $stmt = $pdo->prepare("SELECT title, content FROM exercises WHERE id = ?");
+    $stmt->execute([$exercise_id]);
+    $exercise = $stmt->fetch();
+    if (!$exercise) throw new Exception("Exercise not found.");
+
+    $parser = new ExerciseParser();
+    $Parsedown = new Parsedown();
+    $elements = $parser->parse($exercise['content']);
+
+    // We still need the question IDs for form submission, so we'll fetch them.
+    // A mapping from question order to question ID.
+    $stmt_q_ids = $pdo->prepare("SELECT id, question_order FROM questions WHERE exercise_id = ?");
+    $stmt_q_ids->execute([$exercise_id]);
+    $question_id_map = $stmt_q_ids->fetchAll(PDO::FETCH_KEY_PAIR);
+
+
+} catch (Exception $e) {
+    $_SESSION['message'] = '<div class="message error">' . $e->getMessage() . '</div>';
+    header('Location: student_dashboard.php');
+    exit;
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Complete Exercise: <?php echo htmlspecialchars($exercise['title']); ?></title>
+    <link rel="stylesheet" href="assets/css/<?php echo $current_theme; ?>-theme.css">
+    <style>
+        .question { margin-bottom: 2rem; border-top: 1px solid #eee; padding-top: 1.5rem; }
+        .content-block { margin-bottom: 1.5rem; }
+        .question p { font-weight: bold; }
+        .options-list { list-style-type: none; padding-left: 0; }
+        .options-list li { margin-bottom: 0.5rem; }
+    </style>
+</head>
+<body>
+    <div class="navbar">
+        <span>Student Area</span>
+        <a href="student_dashboard.php">Back to Dashboard</a>
+    </div>
+
+    <div class="container">
+        <h1><?php echo htmlspecialchars($exercise['title']); ?></h1>
+        <?php echo $message; ?>
+
+        <form action="view_exercise.php?id=<?php echo $exercise_id; ?>" method="POST">
+            <?php foreach ($elements as $element): ?>
+                <?php if ($element['type'] === 'content'): ?>
+                    <div class="content-block">
+                        <?php echo $Parsedown->text($element['text']); ?>
+                    </div>
+                <?php elseif ($element['type'] === 'question'):
+                    $q = $element['data'];
+                    $question_id = $question_id_map[$q['order']] ?? 0;
+                    if (!$question_id) continue; // Skip if question somehow not in DB
+                ?>
+                    <div class="question">
+                        <p><strong><?php echo htmlspecialchars($q['order']) . '. ' . htmlspecialchars($q['text']); ?></strong> (<?php echo $q['points']; ?> points)</p>
+
+                        <?php if ($q['type'] === 'multiple_choice' || $q['type'] === 'multiple_response'): ?>
+                            <ul class="options-list">
+                                <?php
+                                // We need option IDs for submission. We have to fetch them.
+                                $stmt_opts = $pdo->prepare("SELECT id, option_text FROM question_options WHERE question_id = ?");
+                                $stmt_opts->execute([$question_id]);
+                                $options = $stmt_opts->fetchAll();
+                                foreach ($options as $option): ?>
+                                    <li>
+                                        <label>
+                                            <?php if ($q['type'] === 'multiple_response'): ?>
+                                                <input type="checkbox" name="answers[<?php echo $question_id; ?>][]" value="<?php echo $option['id']; ?>">
+                                            <?php else: ?>
+                                                <input type="radio" name="answers[<?php echo $question_id; ?>]" value="<?php echo $option['id']; ?>" required>
+                                            <?php endif; ?>
+                                            <?php echo htmlspecialchars($option['option_text']); ?>
+                                        </label>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php elseif ($q['type'] === 'open_ended'): ?>
+                            <textarea name="answers[<?php echo $question_id; ?>]" rows="5" style="width: 100%;"
+                                      <?php if ($q['char_limit']) echo 'maxlength="' . $q['char_limit'] . '"'; ?>
+                                      required></textarea>
+                            <?php if ($q['char_limit']): ?>
+                                <small>Max characters: <?php echo $q['char_limit']; ?></small>
+                            <?php endif; ?>
+
+                        <?php elseif ($q['type'] === 'cloze_test'): ?>
+                            <div class="cloze-word-list">
+                                <strong>Word List:</strong> <?php echo implode(', ', array_map('htmlspecialchars', $q['cloze_data']['word_list'])); ?>
+                            </div>
+                            <div class="cloze-inputs">
+                                <?php
+                                $num_blanks = count($q['cloze_data']['solution']);
+                                for ($i = 1; $i <= $num_blanks; $i++): ?>
+                                    <div class="form-group">
+                                        <label for="cloze_<?php echo $question_id; ?>_<?php echo $i; ?>">Blank [<?php echo $i; ?>]:</label>
+                                        <input type="text" id="cloze_<?php echo $question_id; ?>_<?php echo $i; ?>" name="answers[<?php echo $question_id; ?>][<?php echo $i; ?>]" required>
+                                    </div>
+                                <?php endfor; ?>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                <?php endif; ?>
+            <?php endforeach; ?>
+
+            <button type="submit">Submit Answers</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This commit adds two major enhancements to the exercise creation and viewing process:

1.  **Exercise Preview:** A "Preview" button has been added to the `create_exercise.php` and `edit_exercise.php` pages. This button uses an AJAX call to a new `ajax_render_exercise.php` script, which parses the current wikitext and returns a rendered HTML preview. This allows teachers to see how the exercise will look to students without needing to save it first.

2.  **Interstitial Content:** The `ExerciseParser` has been rewritten to recognize and capture free-form wikitext placed between question blocks. The student-facing `view_exercise.php` page has been updated to parse the wikitext on-the-fly and render both the questions and the interstitial content in the correct order, using the `Parsedown` library for formatting.