### PR TITLE
Fix: Corregge il rendering Markdown e migliora l'editor

### DIFF
--- a/ajax_render_exercise.php
+++ b/ajax_render_exercise.php
@@ -46,7 +46,7 @@ foreach ($elements as $element) {
     } elseif ($element['type'] === 'question') {
         $q = $element['data'];
         echo '<div class="question-preview">';
-        echo '<p><strong>' . htmlspecialchars($q['order']) . '. ' . htmlspecialchars($q['text']) . '</strong> (' . htmlspecialchars($q['points']) . ' points)</p>';
+        echo '<p><strong>' . htmlspecialchars($q['order']) . '. ' . $Parsedown->line($q['text']) . '</strong> (' . htmlspecialchars($q['points']) . ' points)</p>';
 
         switch ($q['type']) {
             case 'multiple_choice':
@@ -55,7 +55,7 @@ foreach ($elements as $element) {
                 foreach ($q['options'] as $opt) {
                     $icon = $q['type'] === 'multiple_choice' ? '&#9675;' : '&#9744;'; // Circle or Checkbox
                     $style = $opt['is_correct'] ? 'color: green; font-weight: bold;' : '';
-                    echo '<li style="' . $style . '">' . $icon . ' ' . htmlspecialchars($opt['text']) . '</li>';
+                    echo '<li style="' . $style . '">' . $icon . ' ' . $Parsedown->line($opt['text']) . '</li>';
                 }
                 echo '</ul>';
                 break;

--- a/create_exercise.php
+++ b/create_exercise.php
@@ -157,7 +157,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
     <script>
-        const easyMDE = new EasyMDE({element: document.getElementById('content')});
+        const easyMDE = new EasyMDE({
+            element: document.getElementById('content'),
+            toolbar: [
+                "bold", "italic", "strikethrough", "|",
+                "heading-1", "heading-2", "heading-3", "|",
+                "code", "quote", "unordered-list", "ordered-list", "|",
+                "link", "image", "table", "horizontal-rule", "|",
+                "preview", "side-by-side", "fullscreen", "|",
+                "guide"
+            ]
+        });
 
         const previewBtn = document.getElementById('preview-btn');
         const closePreviewBtn = document.getElementById('close-preview-btn');

--- a/edit_article.php
+++ b/edit_article.php
@@ -113,7 +113,7 @@ try {
                 </div>
                 <div class="form-group">
                     <label for="content">Content</label>
-                    <textarea id="content" name="content" rows="15" required><?php echo htmlspecialchars($article['content']); ?></textarea>
+                    <textarea id="content" name="content" rows="15" required><?php echo $article['content']; ?></textarea>
                 </div>
                 <div class="form-group">
                     <label for="edit_summary">Edit Summary (briefly describe your changes)</label>
@@ -127,7 +127,17 @@ try {
 
     <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
     <script>
-        const easyMDE = new EasyMDE({element: document.getElementById('content')});
+        const easyMDE = new EasyMDE({
+            element: document.getElementById('content'),
+            toolbar: [
+                "bold", "italic", "strikethrough", "|",
+                "heading-1", "heading-2", "heading-3", "|",
+                "code", "quote", "unordered-list", "ordered-list", "|",
+                "link", "image", "table", "horizontal-rule", "|",
+                "preview", "side-by-side", "fullscreen", "|",
+                "guide"
+            ]
+        });
     </script>
 </body>
 </html>

--- a/edit_exercise.php
+++ b/edit_exercise.php
@@ -183,7 +183,17 @@ try {
 
 <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
-    const easyMDE = new EasyMDE({element: document.getElementById('content')});
+    const easyMDE = new EasyMDE({
+        element: document.getElementById('content'),
+        toolbar: [
+            "bold", "italic", "strikethrough", "|",
+            "heading-1", "heading-2", "heading-3", "|",
+            "code", "quote", "unordered-list", "ordered-list", "|",
+            "link", "image", "table", "horizontal-rule", "|",
+            "preview", "side-by-side", "fullscreen", "|",
+            "guide"
+        ]
+    });
 
 
     const previewBtn = document.getElementById('preview-btn');

--- a/view_exercise.php
+++ b/view_exercise.php
@@ -156,7 +156,7 @@ try {
                     if (!$question_id) continue; // Skip if question somehow not in DB
                 ?>
                     <div class="question">
-                        <p><strong><?php echo htmlspecialchars($q['order']) . '. ' . htmlspecialchars($q['text']); ?></strong> (<?php echo $q['points']; ?> points)</p>
+                        <p><strong><?php echo htmlspecialchars($q['order']) . '. ' . $Parsedown->line($q['text']); ?></strong> (<?php echo $q['points']; ?> points)</p>
 
                         <?php if ($q['type'] === 'multiple_choice' || $q['type'] === 'multiple_response'): ?>
                             <ul class="options-list">
@@ -173,7 +173,7 @@ try {
                                             <?php else: ?>
                                                 <input type="radio" name="answers[<?php echo $question_id; ?>]" value="<?php echo $option['id']; ?>" required>
                                             <?php endif; ?>
-                                            <?php echo htmlspecialchars($option['option_text']); ?>
+                                            <?php echo $Parsedown->line($option['option_text']); ?>
                                         </label>
                                     </li>
                                 <?php endforeach; ?>
@@ -187,10 +187,13 @@ try {
                             <?php endif; ?>
 
                         <?php elseif ($q['type'] === 'cloze_test'): ?>
-                            <div class="cloze-word-list">
+                            <div class="cloze-text">
+                                <?php echo $Parsedown->text($q['text']); ?>
+                            </div>
+                            <div class="cloze-word-list" style="margin-top: 1rem;">
                                 <strong>Word List:</strong> <?php echo implode(', ', array_map('htmlspecialchars', $q['cloze_data']['word_list'])); ?>
                             </div>
-                            <div class="cloze-inputs">
+                            <div class="cloze-inputs" style="margin-top: 1rem;">
                                 <?php
                                 $num_blanks = count($q['cloze_data']['solution']);
                                 for ($i = 1; $i <= $num_blanks; $i++): ?>


### PR DESCRIPTION
Questo commit risolve due problemi principali:

1.  **Rendering del Markdown incoerente:** In diverse parti dell'applicazione, in particolare nella visualizzazione e anteprima degli esercizi, il testo formattato in Markdown non veniva visualizzato correttamente come HTML. Questo era dovuto all'uso di `htmlspecialchars()` invece della libreria `Parsedown`. Ho sostituito le chiamate errate con `$Parsedown->line()` o `$Parsedown->text()` nei file `ajax_render_exercise.php` e `view_exercise.php`. È stato anche corretto un bug in `view_exercise.php` dove il testo delle domande di completamento (cloze) non veniva mostrato.

2.  **Miglioramento dell'editor di testo (EasyMDE):** L'editor di testo utilizzato per creare e modificare articoli ed esercizi era privo di controlli per l'inserimento di tabelle e per la gerarchia dei titoli. Ho aggiornato la configurazione di EasyMDE in `edit_article.php`, `create_exercise.php` e `edit_exercise.php` per includere questi pulsanti nella barra degli strumenti, migliorando l'usabilità per gli autori dei contenuti.

Inoltre, è stato rimosso un `htmlspecialchars()` non necessario dalla textarea in `edit_article.php` per prevenire problemi di doppio escaping durante la modifica dei contenuti.